### PR TITLE
Remove format integer

### DIFF
--- a/spec/core/account/schemas/AccountTypeEnum.yml
+++ b/spec/core/account/schemas/AccountTypeEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 0
   - 1

--- a/spec/core/account/schemas/ActivityBucketDTO.yml
+++ b/spec/core/account/schemas/ActivityBucketDTO.yml
@@ -13,13 +13,10 @@ properties:
     $ref: "../../../schemas/Height.yml"
   totalFeesPaid:
     type: integer
-    format: int64
     description: Fees paid by the account for this bucket.
   beneficiaryCount:
     type: integer
-    format: int32
     description: Number of times the account has been a beneficiary for this bucket.
   rawScore:
     type: integer
-    format: int64
     description: Importance score for this bucket. This is taken into account to calculate the latest account importance.

--- a/spec/core/block/schemas/BlockMetaDTO.yml
+++ b/spec/core/block/schemas/BlockMetaDTO.yml
@@ -18,9 +18,7 @@ properties:
       $ref: "../../../schemas/Hash256.yml"
   numTransactions:
     type: integer
-    format: int32
     example: 0
   numStatements:
     type: integer
-    format: int32
     example: 1

--- a/spec/core/entity/schemas/EntityDTO.yml
+++ b/spec/core/entity/schemas/EntityDTO.yml
@@ -9,10 +9,8 @@ properties:
     $ref: "../../../schemas/PublicKey.yml"
   version:
     type: integer
-    format: int32
     description: Entity version.
   network:
     $ref: "./NetworkTypeEnum.yml"
   type:
     type: integer
-    format: int32

--- a/spec/core/entity/schemas/NetworkTypeEnum.yml
+++ b/spec/core/entity/schemas/NetworkTypeEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 104
   - 152

--- a/spec/core/node/schemas/NodeInfoDTO.yml
+++ b/spec/core/node/schemas/NodeInfoDTO.yml
@@ -12,7 +12,6 @@ properties:
   version:
     type: integer
     description: Version of the application.
-    format: int32
     example: 0
   publicKey:
     $ref: "../../../schemas/PublicKey.yml"
@@ -23,11 +22,9 @@ properties:
   port:
     type: integer
     description: Port used for the communication.
-    format: int32
     example: 7900
   networkIdentifier:
     type: integer
-    format: int32
     example: 144
   friendlyName:
     type: string

--- a/spec/core/node/schemas/RolesTypeEnum.yml
+++ b/spec/core/node/schemas/RolesTypeEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 1
   - 2

--- a/spec/core/node/schemas/StorageInfoDTO.yml
+++ b/spec/core/node/schemas/StorageInfoDTO.yml
@@ -6,16 +6,13 @@ required:
 properties:
   numBlocks:
     type: integer
-    format: int64
     description: Number of blocks stored.
     example: 245053
   numTransactions:
     type: integer
-    format: int64
     description: Number of transactions stored.
     example: 58590
   numAccounts:
     type: integer
-    format: int64
     description: Number of accounts created.
     example: 177

--- a/spec/core/transaction/schemas/EmbeddedTransactionMetaDTO.yml
+++ b/spec/core/transaction/schemas/EmbeddedTransactionMetaDTO.yml
@@ -15,7 +15,6 @@ properties:
     description: Identifier of the aggregate transaction.
   index:
     type: integer
-    format: int32
     description: Transaction index within the aggregate.
   id:
     type: string

--- a/spec/core/transaction/schemas/TransactionMetaDTO.yml
+++ b/spec/core/transaction/schemas/TransactionMetaDTO.yml
@@ -14,7 +14,6 @@ properties:
     $ref: "../../../schemas/Hash256.yml"
   index:
     type: integer
-    format: int32
     description: Transaction index within the block.
   id:
     type: string

--- a/spec/parameters/limit.yml
+++ b/spec/parameters/limit.yml
@@ -7,4 +7,3 @@ description: |
 required: true
 schema:
   type: integer
-  format: int32

--- a/spec/parameters/pageSize.yml
+++ b/spec/parameters/pageSize.yml
@@ -3,7 +3,6 @@ in: query
 description: Number of transactions to return for each request.
 schema:
   type: integer
-  format: int32
   minimum: 10
   maximum: 100
   default: 10

--- a/spec/plugins/account_link/schemas/AccountLinkActionEnum.yml
+++ b/spec/plugins/account_link/schemas/AccountLinkActionEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 0
   - 1

--- a/spec/plugins/lock_secret/schemas/LockHashAlgorithmEnum.yml
+++ b/spec/plugins/lock_secret/schemas/LockHashAlgorithmEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 0
   - 1

--- a/spec/plugins/metadata/schemas/AccountMetadataTransactionBodyDTO.yml
+++ b/spec/plugins/metadata/schemas/AccountMetadataTransactionBodyDTO.yml
@@ -12,11 +12,9 @@ properties:
     $ref: "../../../schemas/MetadataKey.yml"
   valueSizeDelta:
     type: integer
-    format: int32
     description: Change in value size in bytes.
   valueSize:
     type: integer
-    format: int32
     description: Value size in bytes.
   value:
     $ref: "../../../schemas/MetadataValue.yml"

--- a/spec/plugins/metadata/schemas/MetadataTypeEnum.yml
+++ b/spec/plugins/metadata/schemas/MetadataTypeEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 0
   - 1

--- a/spec/plugins/metadata/schemas/MosaicMetadataTransactionBodyDTO.yml
+++ b/spec/plugins/metadata/schemas/MosaicMetadataTransactionBodyDTO.yml
@@ -15,11 +15,9 @@ properties:
     $ref: "../../../schemas/UnresolvedMosaicId.yml"
   valueSizeDelta:
     type: integer
-    format: int32
     description: Change in value size in bytes.
   valueSize:
     type: integer
-    format: int32
     description: Value size in bytes.
   value:
     $ref: "../../../schemas/MetadataValue.yml"

--- a/spec/plugins/metadata/schemas/NamespaceMetadataTransactionBodyDTO.yml
+++ b/spec/plugins/metadata/schemas/NamespaceMetadataTransactionBodyDTO.yml
@@ -15,11 +15,9 @@ properties:
     $ref: "../../../schemas/NamespaceId.yml"
   valueSizeDelta:
     type: integer
-    format: int32
     description: Change in value size in bytes.
   valueSize:
     type: integer
-    format: int32
     description: Value size in bytes.
   value:
     $ref: "../../../schemas/MetadataValue.yml"

--- a/spec/plugins/mosaic/schemas/MosaicDTO.yml
+++ b/spec/plugins/mosaic/schemas/MosaicDTO.yml
@@ -22,14 +22,12 @@ properties:
     $ref: "../../../schemas/Address.yml"
   revision:
     type: integer
-    format: int32
     description: Number of definitions for the same mosaic.
     example: 1
   flags:
     $ref: "./MosaicFlagsEnum.yml"
   divisibility:
     type : integer
-    format: uint32
     description: |
       Determines up to what decimal place the mosaic can be divided.
       Divisibility of 3 means that a mosaic can be divided into smallest parts of 0.001 mosaics.

--- a/spec/plugins/mosaic/schemas/MosaicDefinitionTransactionBodyDTO.yml
+++ b/spec/plugins/mosaic/schemas/MosaicDefinitionTransactionBodyDTO.yml
@@ -12,14 +12,12 @@ properties:
     $ref: "../../../schemas/BlockDuration.yml"
   nonce:
     type: integer
-    format: int64
     description: Random nonce used to generate the mosaic id.
     example: 0
   flags:
     $ref: "./MosaicFlagsEnum.yml"
   divisibility:
     type : integer
-    format: uint32
     description: |
       Determines up to what decimal place the mosaic can be divided.
       Divisibility of 3 means that a mosaic can be divided into smallest parts of 0.001 mosaics.

--- a/spec/plugins/mosaic/schemas/MosaicFlagsEnum.yml
+++ b/spec/plugins/mosaic/schemas/MosaicFlagsEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 description: |
   - 0x00 (none) - No flags present.
   - 0x01 (supplyMutable) - Mosaic supports supply changes even when mosaic owner owns partial supply.

--- a/spec/plugins/mosaic/schemas/MosaicSupplyChangeActionEnum.yml
+++ b/spec/plugins/mosaic/schemas/MosaicSupplyChangeActionEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 0
   - 1

--- a/spec/plugins/multisig/schemas/MultisigAccountGraphInfoDTO.yml
+++ b/spec/plugins/multisig/schemas/MultisigAccountGraphInfoDTO.yml
@@ -5,7 +5,6 @@ required:
 properties:
   level:
     type: integer
-    format: int32
     description: Level of the multisig account.
     example: 0
   multisigEntries:

--- a/spec/plugins/multisig/schemas/MultisigAccountModificationTransactionBodyDTO.yml
+++ b/spec/plugins/multisig/schemas/MultisigAccountModificationTransactionBodyDTO.yml
@@ -7,14 +7,12 @@ required:
 properties:
   minRemovalDelta:
     type: integer
-    format: int32
     description: |
       Number of signatures needed to remove a cosignatory.
       If we are modifying an existing multisig account, this indicates the relative change of the minimum cosignatories.
     example: 1
   minApprovalDelta:
     type: integer
-    format: int32
     description: |
       Number of signatures needed to approve a transaction.
       If we are modifying an existing multisig account, this indicates the relative change of the minimum cosignatories.

--- a/spec/plugins/multisig/schemas/MultisigDTO.yml
+++ b/spec/plugins/multisig/schemas/MultisigDTO.yml
@@ -13,13 +13,11 @@ properties:
     $ref: "../../../schemas/Address.yml"
   minApproval:
     type: integer
-    format: int32
     description: Number of signatures needed to approve a transaction.
     example: 2
   minRemoval:
     description: Number of signatures needed to remove a cosignatory.
     type: integer
-    format: int32
     example: 1
   cosignatoryPublicKeys:
     type: array

--- a/spec/plugins/namespace/schemas/AliasActionEnum.yml
+++ b/spec/plugins/namespace/schemas/AliasActionEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 0
   - 1

--- a/spec/plugins/namespace/schemas/AliasTypeEnum.yml
+++ b/spec/plugins/namespace/schemas/AliasTypeEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 0
   - 1

--- a/spec/plugins/namespace/schemas/NamespaceDTO.yml
+++ b/spec/plugins/namespace/schemas/NamespaceDTO.yml
@@ -14,7 +14,6 @@ properties:
     $ref: "./NamespaceRegistrationTypeEnum.yml"
   depth:
     type: integer
-    format: int32
     description: Level of the namespace.
     example: 1
   level0:

--- a/spec/plugins/namespace/schemas/NamespaceMetaDTO.yml
+++ b/spec/plugins/namespace/schemas/NamespaceMetaDTO.yml
@@ -12,4 +12,3 @@ properties:
     description: If true, the namespace is active.
   index:
     type: integer
-    format: int32

--- a/spec/plugins/namespace/schemas/NamespaceRegistrationTypeEnum.yml
+++ b/spec/plugins/namespace/schemas/NamespaceRegistrationTypeEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 0
   - 1

--- a/spec/plugins/receipt/schemas/ReceiptDTO.yml
+++ b/spec/plugins/receipt/schemas/ReceiptDTO.yml
@@ -5,7 +5,6 @@ required:
 properties:
   version:
     type: integer
-    format: int32
     description: Version of the receipt.
   type:
     $ref: "./ReceiptTypeEnum.yml"

--- a/spec/plugins/receipt/schemas/ReceiptTypeEnum.yml
+++ b/spec/plugins/receipt/schemas/ReceiptTypeEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 4685
   - 4942

--- a/spec/plugins/receipt/schemas/SourceDTO.yml
+++ b/spec/plugins/receipt/schemas/SourceDTO.yml
@@ -6,12 +6,10 @@ required:
 properties:
   primaryId:
     type: integer
-    format: int32
     description: Transaction index within the block.
     example: 1
   secondaryId:
     type: integer
-    format: int32
     description: |
       Transaction index within the aggregate transaction.
       If the transaction is not an inner transaction, then the secondary id is set to 0.

--- a/spec/plugins/restriction_account/schemas/AccountRestrictionFlagsEnum.yml
+++ b/spec/plugins/restriction_account/schemas/AccountRestrictionFlagsEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 example: 1
 enum:
   - 1

--- a/spec/plugins/restriction_mosaic/schemas/MosaicRestrictionEntryTypeEnum.yml
+++ b/spec/plugins/restriction_mosaic/schemas/MosaicRestrictionEntryTypeEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 0
   - 1

--- a/spec/plugins/restriction_mosaic/schemas/MosaicRestrictionTypeEnum.yml
+++ b/spec/plugins/restriction_mosaic/schemas/MosaicRestrictionTypeEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 0
   - 1

--- a/spec/plugins/transfer/schemas/MessageTypeEnum.yml
+++ b/spec/plugins/transfer/schemas/MessageTypeEnum.yml
@@ -1,5 +1,4 @@
 type: integer
-format: int32
 enum:
   - 0
   - 1

--- a/spec/schemas/BlockFeeMultiplier.yml
+++ b/spec/schemas/BlockFeeMultiplier.yml
@@ -1,4 +1,3 @@
 type: integer
-format: int32
 description: Fee multiplier applied to transactions contained in block.
 example: 0


### PR DESCRIPTION
Related https://github.com/nemtech/symbol-openapi/pull/86

Removed the format property from all integers. Now all integers have ``format:int32`` by default. 

Let me know if this works for you.