### PR TITLE
Added unique params names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.8.9] - 19-Mar-2020
+
+Targets catapult-rest 1.0.20.22
+
+### Changed
+
+- Parameters split in two folders "query" and "parameters"
+- Parameters names are now unique.
+
 ## [0.8.7] - 09-Mar-2020
 
 Targets catapult-rest 1.0.20.22

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "symbol-openapi",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symbol-openapi",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "OpenAPI Specification of catapult-rest",
   "main": "index.js",
   "scripts": {

--- a/spec/info.yml
+++ b/spec/info.yml
@@ -1,4 +1,4 @@
-version: 0.8.8
+version: 0.8.9
 title: Catapult REST Endpoints
 description: OpenAPI Specification of catapult-rest 1.0.20.22
 license:

--- a/spec/parameters/_index.yml
+++ b/spec/parameters/_index.yml
@@ -1,30 +1,30 @@
 # path
-accountId:
+accountIdPath:
   $ref: './path/accountId.yml'
-height:
+heightPath:
   $ref: './path/height.yml'
-limit:
+limitPath:
   $ref: './path/limit.yml'
-metadataKey:
+metadataKeyPath:
   $ref: './path/metadataKey.yml'
-mosaicId:
+mosaicIdPath:
   $ref: './path/mosaicId.yml'
-namespaceId:
+namespaceIdPath:
   $ref: './path/namespaceId.yml'
-publicKey:
+publicKeyPath:
   $ref: './path/publicKey.yml'
-receiptHash:
+receiptHashPath:
   $ref: './path/receiptHash.yml'
-transactionHash:
+transactionHashPath:
   $ref: './path/transactionHash.yml'
-transactionId:
+transactionIdPath:
   $ref: './path/transactionId.yml'
 # query
-id:
+idQuery:
   $ref: './query/id.yml'
-ordering:
+orderingQuery:
   $ref: './query/ordering.yml'
-pageSize:
+pageSizeQuery:
   $ref: './query/pageSize.yml'
-transactionType:
+transactionTypeQuery:
   $ref: './query/transactionTypes.yml'


### PR DESCRIPTION
I need unique param names because we will have some parameters that could be ``query`` and ``path`` parameters at the same time, for example ``mosaicId``.

This change should not break compatibility with the current SDKs.