### PR TITLE
Package management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,22 @@ cache:
 before_script:
   - npm install -g swagger-cli
   - npm install -g openapi-to-postmanv2
+  - npm install -g yaml-cli
 script:
   - npm run build
   - npm run postman
   - npm test
-
 deploy:
+  - provider: script
+    skip_cleanup: true
+    script: /bin/sh travis/github-pages.sh
+    on:
+      branch: $RELEASE_BRANCH
+  - provider: script
+    skip_cleanup: true
+    script: /bin/sh travis/release.sh
+    on:
+      branch: $RELEASE_BRANCH
   - provider: releases
     skip_cleanup: true
     file:
@@ -21,9 +31,3 @@ deploy:
     api_key: $GITHUB_TOKEN
     on:
       tags: true
-  - provider: pages
-    skip_cleanup: true
-    github_token: $GITHUB_TOKEN
-    local_dir: _build
-    on:
-      branch: master

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "swagger-cli validate _build/openapi3.yml",
     "build": "swagger-cli bundle ./spec/openapi.yml --outfile _build/openapi3.yml --type yaml",
-    "postman": "openapi2postmanv2 -s _build/openapi3.yml -o _build/postman.json -p"
+    "postman": "openapi2postmanv2 -s _build/openapi3.yml -o _build/postman.json -p",
+    "version": "echo $npm_package_version"
   },
   "repository": {
     "type": "git",

--- a/spec/core/account/routes/getAccountPartialTransactions.yml
+++ b/spec/core/account/routes/getAccountPartialTransactions.yml
@@ -2,7 +2,7 @@ tags:
   - Account routes
 summary: Get aggregate bonded transactions information
 description: |
-  Gets an array of aggregate bonded transactions where the account is the sender or requires to cosign the transaction.
+  Gets an array of aggregate bonded transactions where the account is the sender, recipient, or requires to cosign the transaction.
 operationId: getAccountPartialTransactions
 parameters:
   - $ref: "../../../parameters/path/accountId.yml"

--- a/travis/.npmrc
+++ b/travis/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/travis/.npmrc
+++ b/travis/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/travis/github-pages.sh
+++ b/travis/github-pages.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+PUBLICATION_BRANCH=gh-pages
+# Checkout the branch
+REPO_PATH=$PWD
+CURRENT_VERSION=$(npm run version --silent)
+rm -rf $HOME/publish
+cd $HOME
+git clone --branch=$PUBLICATION_BRANCH https://${GITHUB_TOKEN}@github.com/$TRAVIS_REPO_SLUG publish 2>&1 > /dev/null
+cd publish
+# Update pages
+
+cp -r $REPO_PATH/_build/. ./
+# Commit and push latest version
+git add .
+git config user.name  "Travis"
+git config user.email "travis@travis-ci.org"
+git commit -m "Uploading $CURRENT_VERSION docs."
+git push -fq origin $PUBLICATION_BRANCH 2>&1 > /dev/null
+cd $REPO_PATH

--- a/travis/release.sh
+++ b/travis/release.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$TRAVIS_BRANCH" = "$RELEASE_BRANCH" ]; then
+
+  REMOTE_NAME="origin"
+  POST_RELEASE_BRANCH="post-$RELEASE_BRANCH"
+
+  git remote rm $REMOTE_NAME
+
+  echo "Setting remote url https://github.com/${TRAVIS_REPO_SLUG}.git"
+  git remote add $REMOTE_NAME "https://${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git" > /dev/null 2>&1
+
+  echo "Checking out $RELEASE_BRANCH as travis leaves the head detached."
+  git checkout $RELEASE_BRANCH
+
+  CURRENT_VERSION=$(npm run version --silent)
+
+  echo "Current Version"
+  echo "$CURRENT_VERSION"
+  echo ""
+
+  echo "Testing git remote"
+  git branch -vv
+  echo ""
+
+  echo "Creating tag v$CURRENT_VERSION"
+  git tag -fa "v$CURRENT_VERSION" -m "Releasing version $CURRENT_VERSION"
+
+  cp travis/.npmrc $HOME/.npmrc
+
+  echo "Increasing openapi version"
+  npm version patch -m "Increasing version to %s" --git-tag-version false
+
+  CURRENT_VERSION=$(npm run version --silent)
+
+  echo "New Version"
+  echo "$CURRENT_VERSION"
+  echo ""
+
+  yaml set spec/info.yaml version $CURRENT_VERSION
+
+  git add .
+  git commit -m "Creating new version $CURRENT_VERSION"
+
+  echo "Pushing code to $REMOTE_NAME $POST_RELEASE_BRANCH"
+  git push --set-upstream $REMOTE_NAME $RELEASE_BRANCH:$POST_RELEASE_BRANCH
+  echo "Pushing tags to $REMOTE_NAME"
+  git push --tags $REMOTE_NAME
+else
+  echo "Release is disabled"
+fi


### PR DESCRIPTION
Followed the release cycle defined by the SDKs with the following modifications:

* Publishes new version of docs (gh-pages) only when there is a full release
* Attaches the compiled OpenAPI to the GitHub tag, but does not publish a new npm package.
* Updates the version number form the OpenApi spec using the cli tool https://github.com/pandastrike/yaml-cli