### PR TITLE
Get Transactions By Ids for all transaction groups

### DIFF
--- a/spec/core/transaction/routes/getConfirmedTransactions.yml
+++ b/spec/core/transaction/routes/getConfirmedTransactions.yml
@@ -1,0 +1,21 @@
+tags:
+  - Transaction routes
+summary: Get transactions information
+description: Returns confirmed transactions information for a given array of transactionIds.
+operationId: getConfirmedTransactions
+requestBody:
+  $ref: "../../../request_bodies/transactionIds.yml"
+responses:
+  "200":
+    description: success
+    content:
+      application/json:
+        schema:
+          type: array
+          description: Array of transactions information.
+          items:
+            $ref: "../schemas/TransactionInfoDTO.yml"
+  "400":
+    $ref: "../../../responses/InvalidContent.yml"
+  "409":
+    $ref: "../../../responses/InvalidArgument.yml"

--- a/spec/core/transaction/routes/getPartialTransactions.yml
+++ b/spec/core/transaction/routes/getPartialTransactions.yml
@@ -1,8 +1,8 @@
 tags:
   - Transaction routes
 summary: Get transactions information
-description: Returns transactions information for a given array of transactionIds.
-operationId: getTransactionsById
+description: Returns partial transactions information for a given array of transactionIds.
+operationId: getPartialTransactions
 requestBody:
   $ref: "../../../request_bodies/transactionIds.yml"
 responses:

--- a/spec/core/transaction/routes/getUnconfirmedTransactions.yml
+++ b/spec/core/transaction/routes/getUnconfirmedTransactions.yml
@@ -1,0 +1,21 @@
+tags:
+  - Transaction routes
+summary: Get transactions information
+description: Returns unconfirmed transactions information for a given array of transactionIds.
+operationId: getUnconfirmedTransactions
+requestBody:
+  $ref: "../../../request_bodies/transactionIds.yml"
+responses:
+  "200":
+    description: success
+    content:
+      application/json:
+        schema:
+          type: array
+          description: Array of transactions information.
+          items:
+            $ref: "../schemas/TransactionInfoDTO.yml"
+  "400":
+    $ref: "../../../responses/InvalidContent.yml"
+  "409":
+    $ref: "../../../responses/InvalidArgument.yml"

--- a/spec/routes.yml
+++ b/spec/routes.yml
@@ -68,13 +68,15 @@
   get:
     $ref: "./core/transaction/routes/searchConfirmedTransactions.yml"
   post:
-    $ref: "./core/transaction/routes/getTransactionsById.yml"
+    $ref: "./core/transaction/routes/getConfirmedTransactions.yml"
 "/transactions/confirmed/{transactionId}":
   get:
     $ref: "./core/transaction/routes/getConfirmedTransaction.yml"
 "/transactions/unconfirmed":
   get:
     $ref: "./core/transaction/routes/searchUnconfirmedTransactions.yml"
+  post:
+    $ref: "./core/transaction/routes/getUnconfirmedTransactions.yml"
 "/transactions/unconfirmed/{transactionId}":
   get:
     $ref: "./core/transaction/routes/getUnconfirmedTransaction.yml"
@@ -93,6 +95,8 @@
     $ref: "./core/transaction/routes/searchPartialTransactions.yml"
   put:
     $ref: "./plugins/aggregate/routes/announcePartialTransaction.yml"
+  post:
+    $ref: "./core/transaction/routes/getPartialTransactions.yml"
 "/transactions/partial/{transactionId}":
   get:
     $ref: "./core/transaction/routes/getPartialTransaction.yml"


### PR DESCRIPTION
Added get transactions by ids to partial and unconfirmed (not using path params like the other ones)

Fixes https://github.com/nemtech/symbol-openapi/issues/161