### PR TITLE
Fixed filter type

### DIFF
--- a/spec/parameters/query/fromTransferAmount.yml
+++ b/spec/parameters/query/fromTransferAmount.yml
@@ -4,4 +4,4 @@ description: |
   Requires providing the `transferMosaicId` filter.
   Only transfer transactions with a transfer amount of the provided mosaic id, greater or equal than this amount are returned.
 schema:
-  type: integer
+  $ref: "../../schemas/Amount.yml"

--- a/spec/parameters/query/toTransferAmount.yml
+++ b/spec/parameters/query/toTransferAmount.yml
@@ -4,4 +4,4 @@ description: |
   Requires providing the `transferMosaicId` filter.
   Only transfer transactions with a transfer amount of the provided mosaic id, lesser or equal than this amount are returned.
 schema:
-  type: integer
+  $ref: "../../schemas/Amount.yml"


### PR DESCRIPTION
`fromTransferAmount` and `toTransferAmount` should be a unit64 amount (numeric string) instead of just a number