### PR TITLE
Removed id from namespace meta

### DIFF
--- a/spec/plugins/namespace/schemas/NamespaceMetaDTO.yml
+++ b/spec/plugins/namespace/schemas/NamespaceMetaDTO.yml
@@ -1,12 +1,8 @@
 type: object
 required:
-  - id
   - active
   - index
 properties:
-  id:
-    type: string
-    description: Identifier of the namespace entry.
   active:
     type: boolean
     description: If true, the namespace is active.


### PR DESCRIPTION
This field has been moved to the top-level

https://github.com/nemtech/symbol-openapi/blob/main/spec/plugins/namespace/schemas/NamespaceInfoDTO.yml#L3

![image](https://user-images.githubusercontent.com/5390558/97721405-2905b580-1aa8-11eb-9f47-9a5b1e8323a3.png)
