### PR TITLE
Namespace Transaction required fields fix

### DIFF
--- a/spec/plugins/namespace/schemas/NamespaceRegistrationTransactionBodyDTO.yml
+++ b/spec/plugins/namespace/schemas/NamespaceRegistrationTransactionBodyDTO.yml
@@ -1,7 +1,5 @@
 type: object
 required:
-  - duration
-  - parentId
   - id
   - registrationType
   - name


### PR DESCRIPTION
On namespace transactions, duration or parent id is required, but not both at the same time. 

If required is in place, user (and generated code) would think that duration and parentid are always provided.